### PR TITLE
Improve PayRequest gateway error handling

### DIFF
--- a/modules/gateways/callback/payrequest.php
+++ b/modules/gateways/callback/payrequest.php
@@ -16,11 +16,16 @@ if (!$gatewayParams['type']) {
 }
 
 // Retrieve data returned in payment gateway callback
-$success = $_POST["status"];
-$invoiceId = $_POST["title"];
-$transactionId = $_POST["link"];
-$paymentAmount = $_POST["amount"];
+$success = $_POST['status'] ?? '';
+$invoiceId = $_POST['title'] ?? '';
+$transactionId = $_POST['link'] ?? '';
+$paymentAmount = $_POST['amount'] ?? 0;
 $paymentFee = 0;
+
+if ($success === '' || $invoiceId === '' || $transactionId === '') {
+    logTransaction($gatewayParams['name'], $_POST, 'Missing callback parameters');
+    die('Invalid callback data');
+}
 
 $transactionStatus = $success==='PAID' ? 'Success' : 'Failure';
 


### PR DESCRIPTION
## Summary
- ensure payment link data includes currency and handles missing API responses
- add robust JSON parsing for API calls
- validate callback parameters before processing

## Testing
- `php -l modules/gateways/payrequest.php`
- `php -l modules/gateways/callback/payrequest.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689352eadbf4832298ef0290f59d6ba9